### PR TITLE
Several refinements

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -11,6 +11,12 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+var isVerbose = args.Contains("-verbose") || args.Contains("-Verbose") || args.Contains("-v") || args.Contains("-V");
+var isBom = args.Contains("-bom") || args.Contains("-BOM") || args.Contains("-b") || args.Contains("-B");
+var isEsc = args.Contains("-esc") || args.Contains("-ESC") || args.Contains("-e") || args.Contains("-E");
 
 var defaultColor = Console.ForegroundColor;
 Console.ForegroundColor = ConsoleColor.DarkCyan;
@@ -47,30 +53,114 @@ To understand the why of the tool, check:
 https://medium.com/@juanal98/trojan-source-in-dotnet-25f6ce190c1a
 ");
 
+var nonRenderingCategories = new UnicodeCategory[] {
+UnicodeCategory.Control,
+UnicodeCategory.OtherNotAssigned,
+UnicodeCategory.Format,
+UnicodeCategory.Surrogate };
 
-static void alert(string text)
+
+void alert(string text, int line)
 {
-    var defaultColor = Console.ForegroundColor;
+    var defaultForegroundColor = Console.ForegroundColor;
+    var defaultBackgroundColor = Console.BackgroundColor;
     Console.ForegroundColor = ConsoleColor.DarkRed;
     Console.Write("[Warning]: ");
-    Console.ForegroundColor = defaultColor;
-    Console.Write("Hidden characters have been detected in: ");
+    Console.ForegroundColor = defaultForegroundColor;
+    Console.Write($"Hidden characters have been detected at line {line} in: ");
     Console.ForegroundColor = ConsoleColor.DarkRed;
     Console.Write(text);
-    Console.ForegroundColor = defaultColor;
+    Console.ForegroundColor = defaultForegroundColor;
     Console.WriteLine();
+
+    if (isVerbose)
+    {
+        var start = Math.Max(0, line);
+        var sourceLines = File.ReadAllLines(text).Skip(start).Take(1).ToArray();
+
+        for (int i = 0; i < sourceLines.Length; ++i)
+        {
+            var sourceLine = sourceLines[i];
+            Console.WriteLine($"appears as: [{start + i}] {sourceLine}");
+
+            Console.Write($"actual    : [{start + i}] ");
+            foreach (var c in sourceLine)
+            {
+                var (isPrintable, slug) = CharConverter(c);
+
+                if (!isPrintable)
+                {
+                    Console.BackgroundColor = ConsoleColor.DarkRed;
+                }
+
+                Console.Write(slug);
+
+                if (!isPrintable)
+                {
+                    Console.BackgroundColor = defaultBackgroundColor;
+                }
+            }
+
+            Console.WriteLine();
+        }
+
+        Console.WriteLine();
+    }
+
+    static (bool isPrintable, string slug) CharConverter(char c)
+    {
+        var nonRenderingCategories = new UnicodeCategory[] {
+        UnicodeCategory.Control,
+        UnicodeCategory.OtherNotAssigned,
+        UnicodeCategory.Format,
+        UnicodeCategory.Surrogate };
+
+        var category = Char.GetUnicodeCategory(c);
+
+        var isPrintable = Char.IsWhiteSpace(c) ||
+                !nonRenderingCategories.Contains(category);
+
+        if (isPrintable) return (true, $"{c}");
+
+        return (false, $"\\u{(ushort)c:X}");
+    }
+
 }
 
-Console.ForegroundColor = ConsoleColor.DarkCyan;
-Console.WriteLine("Please enter a directory with one or more .NET projects to start (Full dir path): ");
-Console.ForegroundColor = defaultColor;
+string? GetPathFromUser()
+{
+    Console.WriteLine();
+    Console.ForegroundColor = ConsoleColor.DarkCyan;
+    Console.WriteLine("Please enter a directory with one or more .NET projects to start (Full dir path): ");
+    Console.ForegroundColor = defaultColor;
 
-var path = Console.ReadLine();
+    return Console.ReadLine();
+}
+
+string? path = null;
+
+while (path is null or "")
+{
+    if (args.Length == 0 || !Directory.Exists(args[0]))
+    {
+        path = GetPathFromUser();
+
+        if (path == string.Empty)
+        {
+            Environment.Exit(0);
+            return;
+        }
+    }
+    else
+    {
+        path = args[0];
+    }
+}
 
 Console.WriteLine();
 
 
-if(string.IsNullOrEmpty(path) || !Directory.Exists(path))
+if (string.IsNullOrEmpty(path) || !Directory.Exists(path))
 {
     Console.ForegroundColor = ConsoleColor.DarkRed;
     Console.WriteLine("Invalid path, check your .NET project directory");
@@ -78,64 +168,102 @@ if(string.IsNullOrEmpty(path) || !Directory.Exists(path))
     return;
 }
 
-string[] dotnetFiles = Directory.GetFiles(path: path, "*.cs", SearchOption.AllDirectories);
+string[] dotnetFiles = Directory.GetFiles(path: path, "*.*", SearchOption.AllDirectories);
+
+// Filter to common C# Project Files
+var regex = new Regex(@".*\.(cs|cshtml|aspx|config|razor|xaml|csproj|resx|ettings\.[^\.]+\.json)$");
 
 var issuesCount = 0;
 
 var scannedFiles = 0;
+var problemFiles = 0;
+
+var problematicFilesList = new List<(string filename, List<int> lines)>();
 
 foreach (var dotnetFile in dotnetFiles)
 {
-    scannedFiles++;
-
-    var nonRenderingCategories = new UnicodeCategory[] {
-    UnicodeCategory.Control,
-    UnicodeCategory.OtherNotAssigned,
-    UnicodeCategory.Format,
-    UnicodeCategory.Surrogate };
-
-    using StreamReader sr = new StreamReader(dotnetFile);
-
-    while (sr.Peek() >= 0)
+    if (regex.IsMatch(dotnetFile))
     {
-        var c = (char)sr.Read();
-        var category = Char.GetUnicodeCategory(c);
+        var lines = new List<int>();
+        int lastReportedLine = -1;
+        scannedFiles++;
 
-        var isPrintable = Char.IsWhiteSpace(c) ||
-              !nonRenderingCategories.Contains(category);
-
-        if (!isPrintable)
+        using StreamReader sr = new StreamReader(dotnetFile);
+        int count = 0, line = 0;
+        while (sr.Peek() >= 0)
         {
-            alert(dotnetFile);
-            issuesCount++;
-            break;
+            var c = (char)sr.Read();
+            count++;
+            if (c == '\n')
+            {
+                line++;
+                continue;
+            }
+            var category = Char.GetUnicodeCategory(c);
+
+            var isPrintable = Char.IsWhiteSpace(c) ||
+                  !nonRenderingCategories.Contains(category);
+
+            // Filter out Byte-Order-Marks and ESC sequences.
+            if ((ushort)c == 0xFEFF && isBom)
+            {
+                continue;
+            }
+
+            if ((ushort)c == 0x7f && isEsc)
+            {
+                continue;
+            }
+
+            if (!isPrintable)
+            {
+                issuesCount++;
+
+                if (lastReportedLine == -1)
+                {
+                    problemFiles++;
+                }
+
+                if (lastReportedLine != line)
+                {
+                    lines.Add(line);
+                    lastReportedLine = line;
+                    alert(dotnetFile, line);
+                }
+            }
+        }
+
+        sr.Close();
+
+        sr.Dispose();
+
+        if (lines.Count > 0)
+        {
+            problematicFilesList.Add((dotnetFile, lines));
         }
     }
-
-    sr.Close();
-
-    sr.Dispose();
 }
 
 
-if(issuesCount == 0)
+if (issuesCount == 0)
 {
     Console.ForegroundColor = ConsoleColor.DarkGreen;
     Console.WriteLine();
     Console.WriteLine($"Perfect! No problems have been detected in the analysis of {scannedFiles} files.");
     Console.ForegroundColor = defaultColor;
-    Console.ReadKey();
     return;
 }
 
 Console.ForegroundColor = ConsoleColor.DarkYellow;
 Console.WriteLine();
-Console.WriteLine($"{issuesCount} compromised files have been detected based on a total of {scannedFiles} files scanned, please review.");
+Console.WriteLine($"{problemFiles} compromised files containing {issuesCount} issues have been detected based on a total of {scannedFiles} files scanned, please review.");
 Console.ForegroundColor = defaultColor;
 
-Console.ReadKey();
-
-
-
-
-
+if (isVerbose)
+{
+    foreach (var (name, list) in problematicFilesList.OrderBy(t => t.filename))
+    {
+        var lines = $"{name}: [{string.Join(",", list)}]";
+        Console.WriteLine(lines);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -44,6 +44,16 @@ TrojanSourceDetector
 
 and put your project/s full directory to scan.
 
+#### Optional Commands
+
+| Flag | Purpose |
+|------|---------|
+| -Verbose (-v) | Output the lines with problems both as they appear and with the unicode character tag displayed. |
+| -ESC (-e) | Exclude escape character (\u7F) |
+| -BOM (-b) | Exclude Unicode Byte-order Marks (\uFEFF) |
+
+If the first parameter is a valid folder, it will be used instead of prompting the user for a folder to scan.
+
 ## Output / Demo
 
 ![result](https://cdn-images-1.medium.com/max/1200/1*MeZx1jiuqHBAVs3_vXaP8w.png)

--- a/TrojanSourceDetector4Dotnet.csproj
+++ b/TrojanSourceDetector4Dotnet.csproj
@@ -10,10 +10,10 @@
     <Description>Easily analyze if your .NET projects have been infected with the tojan source vulnerability.</Description>
     <Copyright>Dotnetsafer</Copyright>
     <PackageId>TrojanSourceDetector</PackageId>
-	<PackAsTool>true</PackAsTool>
-	<ToolCommandName>TrojanSourceDetector</ToolCommandName>
-	<Version>1.0.1</Version>
-	<PackageVersion>1.0.1</PackageVersion>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>TrojanSourceDetector</ToolCommandName>
+    <Version>1.1.0</Version>
+    <PackageVersion>1.1.0</PackageVersion>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
| Flag | Purpose |
|------|---------|
| -Verbose (-v) | Output the lines with problems both as they appear and with the unicode character tag displayed. |
| -ESC (-e) | Exclude escape character (\u7F) |
| -BOM (-b) | Exclude Unicode Byte-order Marks (\uFEFF) |

If the first parameter is a valid folder, it will be used instead of prompting the user for a folder to scan.